### PR TITLE
Add Rishit-dagli to website-maintainers team for 1.28 release

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -335,6 +335,7 @@ teams:
     - raelga # L10n: Spanish
     - remyleone # L10n: French
     - reylejano # L10n: English
+    - Rishit-dagli # 1.28 RT Docs Lead temporary access for the release
     - rlenferink # L10n: German
     - SataQiu # L10n: Chinese
     - seokho-son # L10n: Korean


### PR DESCRIPTION
Temporarily adding myself to the website-maintainers team for write access to the `k/website` repo for the release preparation/release day.

/assign @divya-mohan0209 @natalisucks @reylejano (SIG Docs Chairs)